### PR TITLE
フロントエンド/日付データ取得をTypeScriptに書き換える

### DIFF
--- a/components/buttons/Square.vue
+++ b/components/buttons/Square.vue
@@ -1,9 +1,14 @@
 <template>
   <button
     @click="$emit('click')"
-    :class="[baseClass, isHovered ? color : '']"
+    :class="[
+      baseClass,
+      isHovered ? color : '',
+      !isUse ? 'opacity-50 cursor-not-allowed bg-gray-500 text-white' : '',
+    ]"
     @mouseover="isHovered = true"
     @mouseleave="isHovered = false"
+    :disabled="!isUse"
   >
     {{ label }}
   </button>
@@ -18,6 +23,10 @@ const props = defineProps({
   color: {
     type: String,
     required: false,
+  },
+  isUse: {
+    type: Boolean,
+    default: true,
   },
 });
 

--- a/components/forms/UploadForm.vue
+++ b/components/forms/UploadForm.vue
@@ -43,7 +43,12 @@
           label="コピー"
           color="bg-gray-300"
         />
-        <buttons-square @click="syncData" label="同期" color="bg-blue-300" />
+        <buttons-square
+          @click="syncData"
+          label="同期"
+          color="bg-blue-300"
+          :isUse="false"
+        />
       </div>
     </div>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,8 +6,8 @@
       :current-day="currentDay"
       :current-week="currentWeek"
       :time-data="timeData"
-      @next-month="nextMonth"
-      @prev-month="prevMonth"
+      @next-month="handleNextMonth"
+      @prev-month="handlePrevMonth"
     />
     <CalendarWeeks />
     <Calendar
@@ -25,61 +25,41 @@
 import { ref } from "vue";
 import CalendarHeader from "@/components/calendar/CalendarHeader.vue";
 import Calendar from "@/components/calendar/Calendar.vue";
+import { useDateUtils } from "@/utils/DateUtils";
 
-const currentYear = ref(0);
-const currentMonth = ref(0);
-const currentDay = ref(0); // 現時点では無使用
-const currentWeek = ref(0); // 現時点では無使用
+const {
+  currentYear,
+  currentMonth,
+  currentDay,
+  currentWeek,
+  getCalendarDays,
+  nextMonth,
+  prevMonth,
+} = useDateUtils();
 const timeData = ref({});
-
-const calendarDays = ref([]);
+const calendarDays = ref(
+  getCalendarDays(currentYear.value, currentMonth.value)
+);
 
 const updateTimeData = (newTimeData) => {
   timeData.value = newTimeData;
 };
 
-const fetchCalendar = async (move = "") => {
-  const res = await $fetch("http://localhost:8080/api/calendar", {
-    params: {
-      year: currentYear.value || undefined,
-      month: currentMonth.value || undefined,
-      day: currentDay.value || undefined,
-      week: currentWeek.value || undefined,
-      move,
-    },
-  });
-
-  currentYear.value = res.year;
-  currentMonth.value = res.month;
-  currentDay.value = res.day;
-  currentWeek.value = res.week;
-
-  calendarDays.value = res.days;
+const handleNextMonth = () => {
+  nextMonth();
+  calendarDays.value = getCalendarDays(currentYear.value, currentMonth.value);
 };
 
-const nextMonth = () => fetchCalendar("next");
-const prevMonth = () => fetchCalendar("prev");
+const handlePrevMonth = () => {
+  prevMonth();
+  calendarDays.value = getCalendarDays(currentYear.value, currentMonth.value);
+};
 
 const saveTime = ({ date, start, end }) => {
-  // try{
-  //   同期後の個別送信機能
-  //   await $fetch("http://localhost:8080/api/calendar", {
-  //     method: "POST",
-  // };
   timeData.value[date] = { start, end };
 };
 
 const deleteTime = (date) => {
-  // try{
-  //   同期後の個別送信機能
-  //   await $fetch("http://localhost:8080/api/calendar", {
-  //     method: "DELETE",
-  //     body: { date },
-  //   });
-    
-  // };
   delete timeData.value[date];
 };
-
-fetchCalendar();
 </script>

--- a/utils/DateUtils.ts
+++ b/utils/DateUtils.ts
@@ -1,0 +1,93 @@
+import { ref } from "vue";
+
+interface CalendarDay {
+  date: string;
+  isCurrentMonth: boolean;
+}
+
+export const useDateUtils = () => {
+  const getWeekNumber = (date: Date): number => {
+    const firstDayOfYear = new Date(date.getFullYear(), 0, 1);
+    const pastDaysOfYear =
+      (date.getTime() - firstDayOfYear.getTime()) / 86400000;
+    return Math.ceil((pastDaysOfYear + firstDayOfYear.getDay() + 1) / 7);
+  };
+
+  const currentYear = ref(new Date().getFullYear());
+  const currentMonth = ref(new Date().getMonth() + 1);
+  const currentDay = ref(new Date().getDate());
+  const currentWeek = ref(getWeekNumber(new Date()));
+
+  const getCalendarDays = (year: number, month: number): CalendarDay[] => {
+    const firstDay = new Date(year, month - 1, 1);
+    const lastDay = new Date(year, month, 0);
+    const days: CalendarDay[] = [];
+
+    // 前月の日付を追加
+    const firstDayOfWeek = firstDay.getDay();
+    for (let i = firstDayOfWeek - 1; i >= 0; i--) {
+      const date = new Date(year, month - 1, -i);
+      days.push({
+        date: formatDate(date),
+        isCurrentMonth: false,
+      });
+    }
+
+    // 当月の日付を追加
+    for (let i = 1; i <= lastDay.getDate(); i++) {
+      const date = new Date(year, month - 1, i);
+      days.push({
+        date: formatDate(date),
+        isCurrentMonth: true,
+      });
+    }
+
+    // 次月の日付を追加
+    const remainingDays = 42 - days.length; // 6週間分の日付を確保
+    for (let i = 1; i <= remainingDays; i++) {
+      const date = new Date(year, month, i);
+      days.push({
+        date: formatDate(date),
+        isCurrentMonth: false,
+      });
+    }
+
+    return days;
+  };
+
+  const nextMonth = () => {
+    if (currentMonth.value === 12) {
+      currentYear.value++;
+      currentMonth.value = 1;
+    } else {
+      currentMonth.value++;
+    }
+  };
+
+  const prevMonth = () => {
+    if (currentMonth.value === 1) {
+      currentYear.value--;
+      currentMonth.value = 12;
+    } else {
+      currentMonth.value--;
+    }
+  };
+
+  const formatDate = (date: Date): string => {
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+      2,
+      "0"
+    )}-${String(date.getDate()).padStart(2, "0")}`;
+  };
+
+  return {
+    currentYear,
+    currentMonth,
+    currentDay,
+    currentWeek,
+    getCalendarDays,
+    nextMonth,
+    prevMonth,
+    formatDate,
+  };
+};


### PR DESCRIPTION
### 【実装】
日付データの取得機能をフロントエンド側で実装

### 【目的】
日付データ取得機能をバックエンド側に実装した場合、以下がqueryされる

1. ページの読み込み---当日のデータをqueryするため、リロードするたびにqueryが増える
2. 月の移動---月が移動するたびにqueryされる

よって、公開した場合**とんでもない量の接続が行われるので**経済的によろしくない。
そのため、日付データの取得機能をフロントエンド側で実装した。