### PR TITLE
時間関係のCSS修正

### DIFF
--- a/components/calendar/Calendar.vue
+++ b/components/calendar/Calendar.vue
@@ -18,10 +18,10 @@
         class="text-center text-xs sm:text-sm font-bold text-blue-500 flex flex-col w-full"
       >
         <!--この世の終わりみたいなスクロール実装してるのでそのうち解決する-->
-        <div class="overflow-y-auto max-h-[65px] sm:max-h-[100px] mt-[-10px]">
-          <div v-for="(timeSlot, index) in timeData[date.date]" :key="index">
-            {{ timeSlot.start }} ~ {{ timeSlot.end }}
-          </div>
+        <div
+          class="overflow-y-auto max-h-[65px] sm:max-h-[100px] mt-[-10px] whitespace-pre-line"
+        >
+          {{ formatTimeForDisplay(timeData[date.date]) }}
         </div>
       </div>
     </div>
@@ -42,6 +42,7 @@
 <script setup>
 import TimeForm from "@/components/forms/TimeForm.vue";
 import { ref } from "vue";
+import { useTimeUtils } from "@/utils/TimeUtils";
 
 const props = defineProps({
   calendarDays: Array,
@@ -52,6 +53,7 @@ const props = defineProps({
 const emit = defineEmits(["save", "delete", "update:time-data"]);
 
 const timeData = ref({});
+const { formatTimeForDisplay } = useTimeUtils();
 
 const onSave = (data) => {
   timeData.value[data.date] = data.timeSlots;

--- a/components/forms/TimeForm.vue
+++ b/components/forms/TimeForm.vue
@@ -69,6 +69,7 @@
 import { ref, onMounted, onBeforeUnmount, computed, nextTick } from "vue";
 import { DateTimePicker } from "vue-drumroll-datetime-picker";
 import "vue-drumroll-datetime-picker/dist/style.css";
+import { useTimeUtils } from "@/utils/TimeUtils";
 
 const props = defineProps({
   close: Function,
@@ -84,29 +85,16 @@ const props = defineProps({
 
 const emit = defineEmits(["save", "delete"]);
 
-const timeSlots = ref([
-  {
-    start: props.existingTime.start || "",
-    end: props.existingTime.end || "",
-  },
-]);
+const { timeSlots, addTimeSlot, removeTimeSlot, validateTime } = useTimeUtils();
 
-const addTimeSlot = () => {
-  timeSlots.value.push({
-    start: "",
-    end: "",
-  });
-  nextTick(() => {
-    const container = document.querySelector(".max-h-\\[30vh\\]");
-    if (container) {
-      container.scrollTop = container.scrollHeight;
-    }
-  });
-};
-
-const removeTimeSlot = (index) => {
-  timeSlots.value.splice(index, 1);
-};
+if (props.existingTime.start && props.existingTime.end) {
+  timeSlots.value = [
+    {
+      start: props.existingTime.start,
+      end: props.existingTime.end,
+    },
+  ];
+}
 
 const dateComponents = computed(() => {
   const parts = props.selectedDate.split("-");
@@ -133,11 +121,7 @@ const isCurrentMonth = computed(() => {
 });
 
 const save = () => {
-  const hasEmptySlots = timeSlots.value.some(
-    (slot) => !slot.start || !slot.end
-  );
-
-  if (hasEmptySlots) {
+  if (!validateTime(timeSlots.value)) {
     alert("開始時刻と終了時刻を入力してください");
     return;
   }

--- a/components/forms/UploadForm.vue
+++ b/components/forms/UploadForm.vue
@@ -31,21 +31,18 @@
           class="border p-4 rounded"
         >
           <div class="font-bold">{{ formatDate(date) }}</div>
-          <div
-            v-for="(timeSlot, index) in timeSlots"
-            :key="index"
-            class="text-blue-500"
-          >
-            {{ timeSlot.start }} ~ {{ timeSlot.end }}
+          <div class="text-blue-500 whitespace-pre-line">
+            {{ formatTimeForDisplay(timeSlots) }}
           </div>
         </div>
       </div>
 
       <div class="mt-6 flex justify-end gap-4 sticky bottom-0 bg-white pb-6">
         <buttons-square
-          @click="copyToClipboard"
+          @click="handleCopy"
           label="コピー"
           color="bg-gray-300"
+          :isUse="Object.keys(displayData).length > 0"
         />
         <buttons-square
           @click="syncData"
@@ -61,6 +58,8 @@
 
 <script setup>
 import { onMounted, onUnmounted, ref, watch } from "vue";
+import { useTimeUtils } from "@/utils/TimeUtils";
+import { copyToClipboard } from "@/utils/CopyDate";
 
 const props = defineProps({
   timeData: {
@@ -71,6 +70,7 @@ const props = defineProps({
 
 const emit = defineEmits(["close"]);
 const displayData = ref({});
+const { formatTimeForDisplay } = useTimeUtils();
 
 watch(
   () => props.timeData,
@@ -86,33 +86,8 @@ const handleEscKey = (event) => {
   }
 };
 
-const formatDate = (dateString) => {
-  const date = new Date(dateString);
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日(${
-    weekdays[date.getDay()]
-  })`;
-};
-
-const copyToClipboard = () => {
-  if (Object.keys(displayData.value).length === 0) {
-    alert("コピーするデータがありません");
-    return;
-  }
-
-  const text = Object.entries(displayData.value)
-    .map(([date, timeSlots]) => {
-      const timeStrings = timeSlots
-        .map((time) => `${time.start} ~ ${time.end}`)
-        .join(",");
-      return `${formatDate(date)}:  ${timeStrings}`;
-    })
-    .join("\n");
-
-  navigator.clipboard
-    .writeText(text)
-    .then(() => alert("クリップボードにコピーしました"))
-    .catch((err) => console.error("コピーに失敗しました:", err));
+const handleCopy = () => {
+  copyToClipboard(displayData.value);
 };
 
 const syncData = async () => {

--- a/utils/CopyDate.ts
+++ b/utils/CopyDate.ts
@@ -1,0 +1,39 @@
+import { useTimeUtils } from "@/utils/TimeUtils";
+
+// 表示形式を変更できるよう将来的に変更
+export const formatDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+  return `${date.getMonth() + 1}/${date.getDate()}(${weekdays[date.getDay()]})`;
+};
+
+// 年を表示する用
+// ${date.getFullYear()}年
+
+export const copyToClipboard = (
+  displayData: Record<string, any>
+): Promise<void> => {
+  // コピーデータがない場合ボタンが押せないものの、一応警告を出す
+  if (Object.keys(displayData).length === 0) {
+    alert("コピーするデータがありません");
+    return Promise.reject("データがありません");
+  }
+  // コピーデータはTimeUtilsからインポート
+  const { formatTimeForCopy } = useTimeUtils();
+
+  // コピーデータ作成
+  const text = Object.entries(displayData)
+    .map(([date, timeSlots]) => {
+      return `${formatDate(date)}:${formatTimeForCopy(timeSlots)}`;
+    })
+    .join("\n");
+
+  // クリップボードにコピー
+  return navigator.clipboard
+    .writeText(text)
+    .then(() => alert("クリップボードにコピーしました"))
+    .catch((err) => {
+      console.error("コピーに失敗しました:", err);
+      throw err;
+    });
+};

--- a/utils/TimeUtils.ts
+++ b/utils/TimeUtils.ts
@@ -1,0 +1,77 @@
+import { ref } from "vue";
+
+export interface TimeSlot {
+  start: string;
+  end: string;
+}
+
+export const useTimeUtils = () => {
+  const timeSlots = ref<TimeSlot[]>([
+    {
+      start: "",
+      end: "",
+    },
+  ]);
+
+  const addTimeSlot = () => {
+    timeSlots.value.push({
+      start: "",
+      end: "",
+    });
+  };
+
+  const removeTimeSlot = (index: number) => {
+    timeSlots.value.splice(index, 1);
+  };
+
+  const validateTime = (timeSlots: TimeSlot[]) => {
+    return !timeSlots.some((slot) => !slot.start || !slot.end);
+  };
+
+  // 時間の表示テキストを変更(表示用)
+  const formatTimeForDisplay = (timeSlots: TimeSlot[]) => {
+    return timeSlots
+      .map((time) => {
+        // 開始時刻が00:00かつ終了時刻が00:00の場合
+        if (time.start === "00:00" && time.end === "00:00") {
+          return "終日";
+        }
+        // 終了時刻が00:00の場合
+        else if (time.end === "00:00") {
+          return `${time.start}~終日`;
+        }
+        // 開始時刻が00:00の場合
+        else if (time.start === "00:00") {
+          return `~${time.end}`;
+        }
+        // 通常の時間表示
+        return `${time.start}~${time.end}`;
+      })
+      .join("\n");
+  };
+
+  // 時間の表示テキストを変更(コピー用)
+  const formatTimeForCopy = (timeSlots: TimeSlot[]) => {
+    return timeSlots
+      .map((time) => {
+        if (time.start === "00:00" && time.end === "00:00") {
+          return "終日";
+        } else if (time.end === "00:00") {
+          return `${time.start}~終日`;
+        } else if (time.start === "00:00") {
+          return `~${time.end}`;
+        }
+        return `${time.start}~${time.end}`;
+      })
+      .join(", ");
+  };
+
+  return {
+    timeSlots,
+    addTimeSlot,
+    removeTimeSlot,
+    validateTime,
+    formatTimeForDisplay,
+    formatTimeForCopy,
+  };
+};


### PR DESCRIPTION
### 【目的】
時間の表記を以下のように変更する
18:00～00:00 → 18:00～終日
00:00～00:00 → ～12:00
00:00～00:00 → 終日
### 【変更点】
・timeForm.vueの時間入力関係(timeSlotとか)の関数を削除しTimeUtils.tsに移動(コンポーネント分割)
・TimeUtils.tsに時間の表記を変更する機能を追加
・UploadForm.vueのコピー関係の関数を削除しCopyDate.tsに移動(コンポーネント分割)